### PR TITLE
Look for ini files in platform-specific location.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -200,8 +200,6 @@ pub fn firefox_version(binary: &Path) -> Result<AppVersion, Error>  {
     Ok(version)
 }
 
-
-
 #[derive(Debug)]
 pub enum Error {
     /// Error parsing a version string


### PR DESCRIPTION
On macOS ini files are not in the same path as the binary, but in a
Resources/ subdirectory of the parent. So we need to use the correct
platform-specific path or get no metadata.