### PR TITLE
Always work with a canonicalized path for the binary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mozversion"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["James Graham <james@hoppipolla.co.uk>"]
 description = "Utility for accessing Firefox version metadata"
 keywords = ["mozilla", "firefox"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -257,7 +257,11 @@ mod platform {
     use std::path::{Path, PathBuf};
 
     pub fn ini_path(binary: &Path) -> Option<PathBuf> {
-        binary.parent().and_then(|x| x.parent()).map(|x| x.join("Resources"))
+        binary.canonicalize().ok()
+            .as_ref()
+            .and_then(|dir| dir.parent())
+            .and_then(|dir| dir.parent())
+            .map(|dir| dir.join("Resources"))
     }
 }
 
@@ -266,7 +270,10 @@ mod platform {
     use std::path::{Path, PathBuf};
 
     pub fn ini_path(binary: &Path) -> Option<PathBuf> {
-        binary.parent().map(|dir| dir.to_path_buf())
+        binary.canonicalize().ok()
+            .as_ref()
+            .and_then(|dir| dir.parent())
+            .map(|dir| dir.to_path_buf())
     }
 }
 


### PR DESCRIPTION
To be able to retrieve the version information for paths which contain symlinks, the binary path needs to be canonicalized.

@jgraham can you please have a look?